### PR TITLE
Set cache in config and GUI

### DIFF
--- a/PPA-cli.py
+++ b/PPA-cli.py
@@ -10,8 +10,8 @@ argParser.add_argument("--horizontal", type=str, nargs="?", metavar="horizontal_
 argParser.add_argument("--vertical", type=str, nargs="?", metavar="vertical_file_path", default=None, help="The filepath to the vertical image", required=True)
 argParser.add_argument("--improved", type=str, nargs="?", metavar="improved_file_path", default=None, help="The filepath to the improved image after adjusting scope mount")
 
-argParser.add_argument("--cache-dir", type=str, nargs="?", default=PPA_lib.get_cache_file_path(), help="Filepath to look in for cached .wcs files")
-argParser.add_argument("--config", type=str, nargs="?", default=PPA_lib.get_config_file_path(), help="Filepath to config to use")
+argParser.add_argument("--cache-dir", type=str, nargs="?", help="Filepath to look in for cached .wcs files")
+argParser.add_argument("--config", type=str, nargs="?", help="Filepath to config to use")
 argParser.add_argument("--more-data", type=bool, nargs="?", default=False, help="Returns more detailed information")
 
 args = argParser.parse_args()
@@ -28,7 +28,7 @@ cache_dir = args.cache_dir
 return_more_data = args.more_data
 solver = args.solver
 
-config = PPA_lib.PPAConfig()
+config = PPA_lib.PPAConfig(config_file_path)
 
 
 def solve_img(imagePath):

--- a/PPA-cli.py
+++ b/PPA-cli.py
@@ -29,20 +29,21 @@ return_more_data = args.more_data
 solver = args.solver
 
 config = PPA_lib.PPAConfig(config_file_path)
+config.cachedir = cache_dir or config.cachedir
 
 
 def solve_img(imagePath):
-    PPA_lib.plate_solve(config, imagePath, solver, cache_dir=cache_dir)
+    PPA_lib.plate_solve(config, imagePath, solver)
 
 
 # Solve images
 hImgPath = args.horizontal
-hWcsPath = PPA_lib.get_wcs_file_path(hImgPath, cache_dir)
+hWcsPath = PPA_lib.get_wcs_file_path(config, hImgPath)
 solve_img(hImgPath)
 hdulist_h = fits.open(hWcsPath)
 
 vImgPath = args.vertical
-vWcsPath = PPA_lib.get_wcs_file_path(vImgPath, cache_dir)
+vWcsPath = PPA_lib.get_wcs_file_path(config, vImgPath)
 solve_img(vImgPath)
 hdulist_v = fits.open(vWcsPath)
 
@@ -50,7 +51,7 @@ iImgPath = args.improved
 iWcsPath = None
 hdulist_i = None
 if iImgPath is not None:
-    iWcsPath = PPA_lib.get_wcs_file_path(iImgPath, cache_dir)
+    iWcsPath = PPA_lib.get_wcs_file_path(config, iImgPath)
     solve_img(iImgPath)
     hdulist_i = fits.open(iWcsPath)
 

--- a/PPA.py
+++ b/PPA.py
@@ -126,8 +126,11 @@ class PhotoPolarAlign(Frame):
         win.geometry('480x600')
         win.title('Settings')
 
+        var_cachedir = StringVar(value=self.config.cachedir)
+
         var_apikey = StringVar(value=self.config.apikey)
         var_restrict_scale = IntVar(value=self.config.restrict_scale)
+
         var_local_shell = StringVar(value=self.config.local_shell)
         var_local_downscale = IntVar(value=self.config.local_downscale)
         var_local_configfile = StringVar(value=self.config.local_configfile)
@@ -135,6 +138,13 @@ class PhotoPolarAlign(Frame):
         var_local_scale_low = DoubleVar(value=self.config.local_scale_low)
         var_local_scale_hi = DoubleVar(value=self.config.local_scale_hi)
         var_local_xtra = StringVar(value=self.config.local_xtra)
+
+        frm = LabelFrame(win, borderwidth=2, relief='ridge', text='Settings')
+        frm.pack(side='top', ipadx=20, padx=20, fill='x')
+        nxt = Label(frm, text='Cache Directory')
+        nxt.grid(row=0, column=0, pady=4, sticky='w')
+        nxt = Entry(frm, textvariable=var_cachedir)
+        nxt.grid(row=0, column=1, pady=4)
 
         frm = LabelFrame(win, borderwidth=2, relief='ridge', text='nova.astrometry.net')
         frm.pack(side='top', ipadx=20, padx=20, fill='x')
@@ -209,6 +219,7 @@ class PhotoPolarAlign(Frame):
         nxt.grid(row=7, column=0, pady=4, sticky='we', columnspan=3)
 
         def set_and_save_settings():
+            self.config.cachedir = var_cachedir.get()
             self.config.apikey = var_apikey.get()
             self.config.restrict_scale = var_restrict_scale.get()
             self.config.local_shell = var_local_shell.get()
@@ -781,9 +792,34 @@ class PhotoPolarAlign(Frame):
         nxt.pack(anchor='w')
         self.wstat = nxt
 
-    # Some CLI
     def __init__(self, master=None):
-        PPA_lib.init_ppa(self)
+        import numpy
+        # a F8Ib 2.0 mag star, Alpha Ursa Minoris
+        self.polaris = numpy.array([[037.954561, 89.264109]], numpy.float64)
+        #
+        # a M1III 6.4 mag star, Lambda Ursa Minoris
+        self.lam = numpy.array([[259.235229, 89.037706]], numpy.float64)
+        #
+        # a F0III 5.4 mag star, Sigma Octans
+        self.sigma = numpy.array([[317.195164, -88.956499]], numpy.float64)
+        #
+        # a K3IIICN 5.3 mag star, Chi Octans
+        self.chi = numpy.array([[283.696388, -87.605843]], numpy.float64)
+        #
+        # a M1III 7.2 mag star, HD90104
+        self.red = numpy.array([[130.522862, -89.460536]], numpy.float64)
+        #
+        # the pixel coords of the RA axis, if solution exists
+        self.axis = None
+        self.havea = False
+
+        self.scale = None
+        self.havescale = False
+        # the Settings window
+        self.settings_win = None
+        # the User preferences file
+        self.config = PPA_lib.PPAConfig()
+
         master.geometry(self.config.usergeo)
 
         # the filenames of images

--- a/PPA_lib.py
+++ b/PPA_lib.py
@@ -288,9 +288,9 @@ def find_error(axis, hdulist_best):
 
 
 class PPAConfig:
-    def __init__(self):
+    def __init__(self, config_file_path_override=None):
         import configparser
-        self.cfgfn = get_config_file_path()
+        self.cfgfn = config_file_path_override or get_config_file_path()
         self.config_original = configparser.ConfigParser()
         self.config_original.read(self.cfgfn)
 

--- a/PPA_lib.py
+++ b/PPA_lib.py
@@ -142,10 +142,12 @@ def write_config_file(ppa):
     if not ppa.config.config_original.has_section('file'):
         ppa.config.config_original.add_section('file')
     ppa.config.config_original.set('file', 'imgdir', str(ppa.config.imgdir))
+    ppa.config.config_original.set('file', 'cachedir', str(ppa.config.cachedir))
     # the geometry
-    if not ppa.config.config_original.has_section('appearance'):
-        ppa.config.config_original.add_section('appearance')
-    ppa.config.config_original.set('appearance', 'geometry', str(ppa.myparent.winfo_geometry()))
+    # TODO: Stores the current location and size of window, likely to stay the same when reopening.
+    # if not ppa.config.config_original.has_section('appearance'):
+    #     ppa.config.config_original.add_section('appearance')
+    # ppa.config.config_original.set('appearance', 'geometry', str(ppa.myparent.winfo_geometry()))
     # the operating options
     if not ppa.config.config_original.has_section('operations'):
         ppa.config.config_original.add_section('operations')
@@ -314,6 +316,15 @@ class PPAConfig:
         except Exception as e:
             print("Error reading 'imgdir': " + str(e))
             self.imgdir = None
+
+        # ... Cache directory for WCS files
+        try:
+            self.cachedir = self.config_original.get('file', 'cachedir')
+            if self.cachedir is None or self.cachedir == "":
+                self.cachedir = get_cache_file_path()
+        except Exception:
+            self.cachedir = get_cache_file_path()
+
         # ...geometry
         try:
             self.usergeo = self.config_original.get('appearance', 'geometry')
@@ -341,35 +352,6 @@ class PPAConfig:
             #     print("Can't use local astrometry.net solver, check PATH")
         except Exception as e:
             print("Error loading local configs: " + str(e))
-
-
-def init_ppa(ppa):
-    import numpy
-    # a F8Ib 2.0 mag star, Alpha Ursa Minoris
-    ppa.polaris = numpy.array([[037.954561, 89.264109]], numpy.float64)
-    #
-    # a M1III 6.4 mag star, Lambda Ursa Minoris
-    ppa.lam = numpy.array([[259.235229, 89.037706]], numpy.float64)
-    #
-    # a F0III 5.4 mag star, Sigma Octans
-    ppa.sigma = numpy.array([[317.195164, -88.956499]], numpy.float64)
-    #
-    # a K3IIICN 5.3 mag star, Chi Octans
-    ppa.chi = numpy.array([[283.696388, -87.605843]], numpy.float64)
-    #
-    # a M1III 7.2 mag star, HD90104
-    ppa.red = numpy.array([[130.522862, -89.460536]], numpy.float64)
-    #
-    # the pixel coords of the RA axis, if solution exists
-    ppa.axis = None
-    ppa.havea = False
-
-    ppa.scale = None
-    ppa.havescale = False
-    # the Settings window
-    ppa.settings_win = None
-    # the User preferences file
-    ppa.config = PPAConfig()
 
 
 def local_img2wcs(config, filename, wcsfn, scale: float = None):


### PR DESCRIPTION
The CLI is able to change what cache location is used. GUI should also be able to. For GUI to be able to it should be stored in the config. The CLI should use the config for cache then as well. It would likely be useful for the CLI to still be able to take a cache path override in the arguments for a script to determine where they be stored.